### PR TITLE
Reduced garbage produced each OnGUI tick.

### DIFF
--- a/AnimationHierarchyEditor.cs
+++ b/AnimationHierarchyEditor.cs
@@ -113,8 +113,10 @@ public class AnimationHierarchyEditor : EditorWindow {
 			GUILayout.Label("Object:", GUILayout.Width(columnWidth));
 			EditorGUILayout.EndHorizontal();
 			
-			if (paths != null) {
-				foreach (string path in pathsKeys) {
+			if (paths != null) 
+			{
+				foreach (string path in pathsKeys) 
+				{
 					GUICreatePathItem(path);
 				}
 			}
@@ -182,10 +184,6 @@ public class AnimationHierarchyEditor : EditorWindow {
 		} catch (UnityException ex) {
 			Debug.LogError(ex.Message);
 		}
-
-		
-		FillModel();
-		this.Repaint();
 	}
 	
 	void OnInspectorUpdate() {
@@ -335,6 +333,7 @@ public class AnimationHierarchyEditor : EditorWindow {
 		}
 		EditorUtility.ClearProgressBar();
 		FillModel();
+		this.Repaint();
 	}
 	
 	GameObject FindObjectInRoot(string path) {


### PR DESCRIPTION
With long animation or many curves, the editor would slow to a crawl, creating lots of useless data.
Now FillModel is not called for every curve, but only in UpdatePath, so when something actually changed.
